### PR TITLE
Fix SIGSEGV init crash when CS9711 device returns unexpected data

### DIFF
--- a/libfprint/drivers/cs9711/cs9711.c
+++ b/libfprint/drivers/cs9711/cs9711.c
@@ -135,15 +135,24 @@ m_init_read_cb_check_expected (FpiUsbTransfer *transfer,
     {
       fp_dbg ("Read %lu of requested %lu", transfer->length, transfer->actual_length);
       if (transfer->actual_length != CS9711_FP_CMD_LEN_1)
-        fp_warn ("Error; expected %lu bytes but got %lu, continuing", (gsize)CS9711_FP_CMD_LEN_1, transfer->actual_length);
+        {
+          fp_err ("Error; expected %lu bytes but got %lu, failing", (gsize)CS9711_FP_CMD_LEN_1, transfer->actual_length);
+          error = g_error_new (FP_DEVICE_ERROR, FP_DEVICE_ERROR_PROTO,
+                               "Init: expected %lu bytes but got %lu",
+                               (gsize)CS9711_FP_CMD_LEN_1, transfer->actual_length);
+          fpi_ssm_mark_failed (transfer->ssm, error);
+        }
       else if (memcmp (transfer->buffer, expected, CS9711_FP_CMD_LEN_1)) {
         if (!user_data_is_ignore_mismatch_if_non_null) {
           fp_warn ("Error; got different state response than expected, but don't understand it anyway, continuing");
         }
+        fpi_ssm_next_state(transfer->ssm);
       }
       else
-        fp_dbg ("Init response valid");
-      fpi_ssm_next_state(transfer->ssm);
+        {
+          fp_dbg ("Init response valid");
+          fpi_ssm_next_state(transfer->ssm);
+        }
     }
 }
 


### PR DESCRIPTION
Fix SIGSEGV init crash when CS9711 device returns unexpected data (8kb fingerprint image data)  instead of init response value

Fix for upstream https://github.com/ddlsmurf/libfprint-CS9711/issues/4 and https://github.com/ddlsmurf/libfprint-CS9711/issues/11