### PR TITLE
sigfm: support OpenCV 5 pkg-config module name

### DIFF
--- a/libfprint/sigfm/meson.build
+++ b/libfprint/sigfm/meson.build
@@ -1,7 +1,7 @@
 
 sigfm_sources = ['sigfm.cpp']
 
-opencv = dependency('opencv4', required: true)
+opencv = dependency('opencv5', 'opencv4', required: true)
 doctest = dependency('doctest', required: true)
 
 libsigfm = static_library('sigfm',


### PR DESCRIPTION
`libfprint/sigfm/meson.build` requires the `opencv4` pkg-config module
unconditionally. OpenCV 5.0 installs `opencv5.pc` and no longer ships
`opencv4.pc`, so on distributions that have moved to OpenCV 5 the build fails
at configure time:

```
Run-time dependency opencv4 found: NO (tried pkg-config and cmake)
libfprint/sigfm/meson.build:4:9: ERROR: Dependency "opencv4" not found (tried pkg-config and cmake)
```

Arch Linux moved to `opencv 5.0.0` on 2026-07-08, which is where I hit this.
It has also been reported independently against the AUR package.

This prefers `opencv5` and falls back to `opencv4`, so both keep working.

Keeping the OpenCV 4 path matters for distributions that haven't moved yet:
Debian stable and the Ubuntu LTS releases will be on OpenCV 4 for some time.

No source changes were needed. The OpenCV API this module uses (`cv::SIFT`,
`cv::BFMatcher`, `cv::Mat`, `cv::KeyPoint`, `cv::DMatch`, `cv::Point2i`) is
unchanged in 5.0. OpenCV 5 does rename the `features2d` library to `features`,
but the `opencv2/features2d.hpp` include still resolves and linking picks up
`libopencv_features.so.500` via pkg-config.